### PR TITLE
Encode cc-serverside-subscriptions

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -28,11 +28,10 @@ jobs:
         uses: actions-mn/cache@v1
 
       - name: Metanorma generate site
-        uses: actions-mn/build-and-publish@main
+        uses: actions-mn/build-and-publish@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           agree-to-terms: true
-
+          destination: gh-pages
   deploy:
     if: ${{ github.ref == 'refs/heads/main' }}
     environment:

--- a/README.adoc
+++ b/README.adoc
@@ -1,22 +1,21 @@
-= CalConnect Standard: (TITLE)
+= CalConnect Standard: Serverside Subscriptions
 
-This work item belongs to CalConnect (TCs).
+This work item belongs to CalConnect TC CALENDAR.
 
 image:https://github.com/CalConnect/cc-serverside-subscriptions/workflows/generate/badge.svg["Build Status", link="https://github.com/CalConnect/cc-serverside-subscriptions/actions?workflow=generate"]
 
 This document is available in its rendered forms here:
 
-* https://calconnect.github.io/cc-serverside-subscriptions/[CalConnect: Calendaring and scheduling -- Vocabulary (HTML)]
+* https://calconnect.github.io/cc-serverside-subscriptions/[CalConnect: Serverside Subscriptions (HTML)]
 
 == General
 
-This document specifies the (TITLE).
+This document specifies the Serverside Subscriptions.
 
 The document is published as the following:
 
-* CalConnect CC (DOCNUMBER)
-* ISO (DOCNUMBER)
-* IETF draft-cc-serverside-subscriptions
+* CalConnect CC 51023
+* IETF draft-ietf-calext-serverside-subscriptions
 
 
 == Fetching the document

--- a/metanorma.yml
+++ b/metanorma.yml
@@ -2,10 +2,9 @@
 metanorma:
   source:
     files:
-      - sources/cc-51008/document.adoc
-      - sources/ietf/document.adoc
-      - sources/iso-51008/document.adoc
+      - sources/cc-51023.adoc
+      - sources/draft-ietf-calext-serverside-subscriptions.adoc
 
   collection:
-    name: vObject and vFormat
+    name: Serverside Subscriptions
     organization: CalConnect

--- a/sources/cc-51023.adoc
+++ b/sources/cc-51023.adoc
@@ -27,6 +27,8 @@ include::sections/02-normative-references.adoc[]
 
 include::sections/03-terms.adoc[]
 
+include::sections/03-conventions.adoc[]
+
 include::sections/04-caldav-subscriptions.adoc[]
 
 include::sections/05-dav-properties.adoc[]

--- a/sources/cc-51023.adoc
+++ b/sources/cc-51023.adoc
@@ -1,0 +1,46 @@
+= Serverside Subscriptions
+:docnumber: 51023
+:copyright-year: 2022
+:language: en
+:doctype: standard
+:edition: 1
+:status: working-draft
+:revdate: 2022-05-18
+:published-date: 2022-05-18
+:technical-committee: CALENDAR
+:fullname: Michael Douglass
+:surname: Douglass
+:givenname: Michael
+:affiliation: Bedework
+:mn-document-class: cc
+:mn-output-extensions: xml,html,pdf,rxl
+:local-cache-only:
+:data-uri-image:
+
+include::sections/00-abstract.adoc[]
+
+include::sections/01-intro.adoc[]
+
+include::sections/01-scope.adoc[]
+
+include::sections/02-normative-references.adoc[]
+
+include::sections/03-terms.adoc[]
+
+include::sections/04-caldav-subscriptions.adoc[]
+
+include::sections/05-dav-properties.adoc[]
+
+include::sections/06-refreshing.adoc[]
+
+include::sections/07-response-delays.adoc[]
+
+include::sections/08-caldav-considerations.adoc[]
+
+include::sections/09-security.adoc[]
+
+include::sections/10-privacy.adoc[]
+
+include::sections/11-iana.adoc[]
+
+include::sections/99-acknowledgements.adoc[]

--- a/sources/draft-ietf-calext-serverside-subscriptions.adoc
+++ b/sources/draft-ietf-calext-serverside-subscriptions.adoc
@@ -1,0 +1,50 @@
+= Serverside Subscriptions
+:doctype: internet-draft
+:name: draft-ietf-calext-serverside-subscriptions-03
+:status: standard
+:ipr: trust200902
+:area: Applications
+:intended-series: standard
+:workgroup: Calendaring Extensions
+:published-date: 2022-05-18
+:updates: IETF RFC 4791
+:fullname: Michael Douglass
+:lastname: Douglass
+:forename_initials: M.
+:affiliation: Bedework
+:address: 226 3rd Street + \
+Troy, NY 12180 + \
+United States of America
+:email: mdouglass@bedework.com
+:contributor-uri: http://bedework.com
+:mn-document-class: ietf
+:mn-output-extensions: xml,rfc,txt,html,rxl
+:local-cache-only:
+:data-uri-image:
+:keywords: icalendar, properties
+
+include::sections-ietf/00-abstract.adoc[]
+
+include::sections/01-intro.adoc[]
+
+include::sections/04-caldav-subscriptions.adoc[]
+
+include::sections/05-dav-properties.adoc[]
+
+include::sections/06-refreshing.adoc[]
+
+include::sections/07-response-delays.adoc[]
+
+include::sections/08-caldav-considerations.adoc[]
+
+include::sections/09-security.adoc[]
+
+include::sections/10-privacy.adoc[]
+
+include::sections/11-iana.adoc[]
+
+include::sections/99-acknowledgements.adoc[]
+
+include::sections-ietf/97-change-log.adoc[]
+
+include::sections-ietf/98-references.adoc[]

--- a/sources/draft-ietf-calext-serverside-subscriptions.adoc
+++ b/sources/draft-ietf-calext-serverside-subscriptions.adoc
@@ -25,7 +25,7 @@ United States of America
 
 include::sections-ietf/00-abstract.adoc[]
 
-include::sections/01-intro.adoc[]
+include::sections-ietf/01-intro.adoc[]
 
 include::sections/04-caldav-subscriptions.adoc[]
 

--- a/sources/sections-ietf/00-abstract.adoc
+++ b/sources/sections-ietf/00-abstract.adoc
@@ -1,10 +1,11 @@
 [abstract]
 == Abstract
 
-This specification provides a mechanism whereby subscriptions to external resources can be
-handled by the server.
+This specification provides a mechanism whereby subscriptions to external
+resources can be handled by the server.
 
-This specification updates <<RFC4791>> to add new properties for the MKCOL request.
+This specification updates <<RFC4791>> to add new properties for the MKCOL
+request.
 
 [NOTE,title=Open Issues]
 ====

--- a/sources/sections-ietf/00-abstract.adoc
+++ b/sources/sections-ietf/00-abstract.adoc
@@ -1,0 +1,12 @@
+[abstract]
+== Abstract
+
+This specification provides a mechanism whereby subscriptions to external resources can be
+handled by the server.
+
+This specification updates <<RFC4791>> to add new properties for the MKCOL request.
+
+[NOTE,title=Open Issues]
+====
+invitations:: Any reason not to allow them?
+====

--- a/sources/sections-ietf/01-intro.adoc
+++ b/sources/sections-ietf/01-intro.adoc
@@ -16,3 +16,9 @@ feed and make it visible in the user's home.
 The advantages are popular feeds can be cached by the server and the user only
 has to make a
 single subscription.
+
+=== Conventions Used in This Document
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in <<RFC2119>>.

--- a/sources/sections-ietf/97-change-log.adoc
+++ b/sources/sections-ietf/97-change-log.adoc
@@ -1,0 +1,19 @@
+[appendix]
+== metanorma-extension
+
+=== document history
+
+[source,yaml]
+----
+- date:
+  - type: created
+    value: 2018-06-26
+  edition: 0
+  contributor:
+  - person:
+      name:
+        abbreviation: MD
+        completename: Michael Douglass
+  amend:
+    - description: First pass
+----

--- a/sources/sections-ietf/98-references.adoc
+++ b/sources/sections-ietf/98-references.adoc
@@ -1,0 +1,17 @@
+== References
+
+[bibliography]
+=== Normative References
+
+* [[[RFC2119,IETF RFC 2119]]]
+* [[[RFC2434,IETF RFC 2434]]]
+* [[[RFC2518,IETF RFC 2518]]]
+* [[[RFC3339,IETF RFC 3339]]]
+* [[[RFC3688,IETF RFC 3688]]]
+* [[[RFC3986,IETF RFC 3986]]]
+* [[[RFC4791,IETF RFC 4791]]]
+* [[[RFC5545,IETF RFC 5545]]]
+* [[[RFC5546,IETF RFC 5546]]]
+* [[[RFC5988,IETF RFC 5988]]]
+* [[[RFC7240,IETF RFC 7240]]]
+* [[[W3C.REC-xml-20060816,W3C.REC-xml-20060816]]], Maler, E., Yergeau, F., Paoli, J., Sperberg-McQueen, M., and T. Bray, "Extensible Markup Language (XML) 1.0 (Fourth Edition)", World Wide Web Consortium Recommendation REC-xml-20060816, August 2006.

--- a/sources/sections-ietf/98-references.adoc
+++ b/sources/sections-ietf/98-references.adoc
@@ -14,4 +14,4 @@
 * [[[RFC5546,IETF RFC 5546]]]
 * [[[RFC5988,IETF RFC 5988]]]
 * [[[RFC7240,IETF RFC 7240]]]
-* [[[W3C.REC-xml-20060816,W3C.REC-xml-20060816]]], Maler, E., Yergeau, F., Paoli, J., Sperberg-McQueen, M., and T. Bray, "Extensible Markup Language (XML) 1.0 (Fourth Edition)", World Wide Web Consortium Recommendation REC-xml-20060816, August 2006.
+* [[[W3C.REC-xml-20060816,W3C REC-xml-20060816]]], Maler, E., Yergeau, F., Paoli, J., Sperberg-McQueen, M., and T. Bray, "Extensible Markup Language (XML) 1.0 (Fourth Edition)", World Wide Web Consortium Recommendation REC-xml-20060816, August 2006.

--- a/sources/sections/00-abstract.adoc
+++ b/sources/sections/00-abstract.adoc
@@ -1,0 +1,6 @@
+[abstract]
+== Abstract
+
+This specification provides a mechanism whereby subscriptions to external resources can be handled by the server.
+
+This specification updates <<RFC4791>> to add new properties for the MKCOL request.

--- a/sources/sections/00-abstract.adoc
+++ b/sources/sections/00-abstract.adoc
@@ -1,6 +1,8 @@
 [abstract]
 == Abstract
 
-This specification provides a mechanism whereby subscriptions to external resources can be handled by the server.
+This specification provides a mechanism whereby subscriptions to external
+resources can be handled by the server.
 
-This specification updates <<RFC4791>> to add new properties for the MKCOL request.
+This specification updates <<RFC4791>> to add new properties for the MKCOL
+request.

--- a/sources/sections/01-intro.adoc
+++ b/sources/sections/01-intro.adoc
@@ -1,0 +1,21 @@
+[[introduction]]
+== Introduction
+
+The motivation for this specification was initially to handle external subscriptions to calendar
+data. However, any resource which allows subscriptions might make use of this specification.
+
+Currently subscriptions to calendar feeds are handled by calendar clients. There are a number of
+disadvantages to this approach: users have to subscribe from multiple devices and the
+subscription cannot affect scheduling handled by the server.
+
+This specification defines a mechanism whereby the server will subscribe to the feed and make it
+visible in the user's home.
+
+The advantages are popular feeds can be cached by the server and the user only has to make a
+single subscription.
+
+=== Conventions Used in This Document
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
+"RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted
+as described in <<RFC2119>>.

--- a/sources/sections/01-scope.adoc
+++ b/sources/sections/01-scope.adoc
@@ -1,0 +1,9 @@
+[[scope]]
+== Scope
+
+//This document specifies a mechanism whereby subscriptions to external resources can be handled
+//by the server. It defines new properties for the MKCOL request to support server-side
+//subscriptions.
+
+//The document is applicable to any resource which allows subscriptions, with a primary focus on
+//calendar data.

--- a/sources/sections/01-scope.adoc
+++ b/sources/sections/01-scope.adoc
@@ -1,9 +1,8 @@
 [[scope]]
 == Scope
 
-//This document specifies a mechanism whereby subscriptions to external resources can be handled
-//by the server. It defines new properties for the MKCOL request to support server-side
-//subscriptions.
+This specification provides a mechanism whereby subscriptions to external
+resources can be handled by the server.
 
-//The document is applicable to any resource which allows subscriptions, with a primary focus on
-//calendar data.
+This specification updates <<RFC4791>> to add new properties for the MKCOL
+request.

--- a/sources/sections/02-normative-references.adoc
+++ b/sources/sections/02-normative-references.adoc
@@ -1,0 +1,15 @@
+[bibliography]
+== Normative references
+
+* [[[RFC2119,IETF RFC 2119]]]
+* [[[RFC2434,IETF RFC 2434]]]
+* [[[RFC2518,IETF RFC 2518]]]
+* [[[RFC3339,IETF RFC 3339]]]
+* [[[RFC3688,IETF RFC 3688]]]
+* [[[RFC3986,IETF RFC 3986]]]
+* [[[RFC4791,IETF RFC 4791]]]
+* [[[RFC5545,IETF RFC 5545]]]
+* [[[RFC5546,IETF RFC 5546]]]
+* [[[RFC5988,IETF RFC 5988]]]
+* [[[RFC7240,IETF RFC 7240]]]
+* [[[W3C.REC-xml-20060816,W3C.REC-xml-20060816]]], Maler, E., Yergeau, F., Paoli, J., Sperberg-McQueen, M., and T. Bray, "Extensible Markup Language (XML) 1.0 (Fourth Edition)", World Wide Web Consortium Recommendation REC-xml-20060816, August 2006.

--- a/sources/sections/02-normative-references.adoc
+++ b/sources/sections/02-normative-references.adoc
@@ -12,4 +12,4 @@
 * [[[RFC5546,IETF RFC 5546]]]
 * [[[RFC5988,IETF RFC 5988]]]
 * [[[RFC7240,IETF RFC 7240]]]
-* [[[W3C.REC-xml-20060816,W3C.REC-xml-20060816]]], Maler, E., Yergeau, F., Paoli, J., Sperberg-McQueen, M., and T. Bray, "Extensible Markup Language (XML) 1.0 (Fourth Edition)", World Wide Web Consortium Recommendation REC-xml-20060816, August 2006.
+* [[[W3C.REC-xml-20060816,W3C REC-xml-20060816]]], Maler, E., Yergeau, F., Paoli, J., Sperberg-McQueen, M., and T. Bray, "Extensible Markup Language (XML) 1.0 (Fourth Edition)", World Wide Web Consortium Recommendation REC-xml-20060816, August 2006.

--- a/sources/sections/03-conventions.adoc
+++ b/sources/sections/03-conventions.adoc
@@ -1,0 +1,5 @@
+== Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in <<RFC2119>>.

--- a/sources/sections/03-terms.adoc
+++ b/sources/sections/03-terms.adoc
@@ -1,0 +1,1 @@
+== Terms and Definitions

--- a/sources/sections/04-caldav-subscriptions.adoc
+++ b/sources/sections/04-caldav-subscriptions.adoc
@@ -3,12 +3,12 @@
 
 === Request
 
-A client will subscribe to a URL by performing a MKCOL request with resource type elements of
-at least DAV:collection and DAV:subscription. For a calendar subscription there will also be a
-caldav calendar element.
+A client will subscribe to a URL by performing a MKCOL request with resource
+type elements of at least DAV:collection and DAV:subscription. For a calendar
+subscription there will also be a caldav calendar element.
 
-This is an example of the MKCOL request and response from a server that supports extended
-MKCOL.
+This is an example of the MKCOL request and response from a server that supports
+extended MKCOL.
 
 [source%unnumbered]
 ----

--- a/sources/sections/04-caldav-subscriptions.adoc
+++ b/sources/sections/04-caldav-subscriptions.adoc
@@ -1,0 +1,47 @@
+[[caldav-subscriptions]]
+== CalDAV Subscriptions
+
+=== Request
+
+A client will subscribe to a URL by performing a MKCOL request with resource type elements of
+at least DAV:collection and DAV:subscription. For a calendar subscription there will also be a
+caldav calendar element.
+
+This is an example of the MKCOL request and response from a server that supports extended
+MKCOL.
+
+[source%unnumbered]
+----
+>> Request <<
+
+POST /caldav/user/mike/calendars/parrots HTTP/1.1
+Host: example.com
+Content-Type: text/calendar; component=VEVENT; method=REQUEST
+Content-Length: xxxx
+
+<?xml version="1.0" encoding="utf-8" ?>
+<D:mkcol xmlns:D="DAV:"
+         xmlns:C="urn:ietf:params:xml:ns:caldav">
+  <D:set>
+    <D:prop>
+      <D:resourcetype>
+        <D:collection/>
+        <C:calendar/>
+        <D:subscription/>
+      </D:resourcetype>
+      <D:displayname>Parrot Events</D:displayname>
+      <D:subscription-href
+          >http://example.org/parrot-events.ics<
+          /D:subscription-href>
+      <D:subscription-deletions-suppressed
+          >true</D:subscription-deletions-suppressed>
+      <D:subscription-suggested-refresh-interval
+          >PT1H</D:subscription-suggested-refresh-interval>
+    </D:prop>
+  </D:set>
+</D:mkcol>
+
+>> Response <<
+
+HTTP/1.1 200 OK
+----

--- a/sources/sections/05-dav-properties.adoc
+++ b/sources/sections/05-dav-properties.adoc
@@ -4,14 +4,19 @@
 === DAV:subscription
 
 Name:: subscription
+
 Namespace:: DAV
-Purpose:: To indicate that the resource is a subscription to an external resource which is
-managed by the server.
+
+Purpose:: To indicate that the resource is a subscription to an external
+resource which is managed by the server.
+
 Conformance:: When this is specified the request MUST also contain at least a
 DAV:subscription-href element as defined in this specification.
-Description:: The DAV:specification resource type element is used to indicate a collection
-that is a subscription. A subscription MUST report the DAV:subscription XML element in the
-value of the DAV: resourcetype property.
+
+Description:: The DAV:specification resource type element is used to indicate a
+collection that is a subscription. A subscription MUST report the
+DAV:subscription XML element in the value of the DAV: resourcetype property.
+
 Definition::
 +
 [source%unnumbered]
@@ -22,10 +27,14 @@ Definition::
 === DAV:subscription-href
 
 Name:: subscription-href
+
 Namespace:: DAV
+
 Purpose:: Provides the url for the external subscription.
-Conformance:: This property MUST be defined on any collection which has a resource-type
-containing a DAV:subscription element.
+
+Conformance:: This property MUST be defined on any collection which has a
+resource-type containing a DAV:subscription element.
+
 Definition::
 +
 [source%unnumbered]
@@ -33,6 +42,7 @@ Definition::
 <!ELEMENT vpoll-max-items (#PCDATA)>
 PCDATA value: a url
 ----
+
 Example::
 +
 [source%unnumbered]
@@ -44,17 +54,24 @@ Example::
 === DAV:subscription-deletions-suppressed
 
 Name:: subscription-deletions-suppressed
+
 Namespace:: DAV
-Purpose:: To indicate that resources that no longer appear in the feed should be retained by
-the server.
+
+Purpose:: To indicate that resources that no longer appear in the feed should be
+retained by the server.
+
 Conformance:: This property MAY be defined on any subscription.
-Description:: Many feeds provide only the current active set of resources. For example, a
-calendar feed may only contain events from the current date onwards - while many subscribers
-would like to retain a copy of all events received over time.
+
+Description:: Many feeds provide only the current active set of resources. For
+example, a calendar feed may only contain events from the current date onwards -
+while many subscribers would like to retain a copy of all events received over
+time.
 +
-This property indicates that the server SHOULD retain resources that disappear from the feed.
-Services MAY define some mechanism to indicate that a particular resource SHOULD be removed.
-For example this specification suggests setting a status of DELETED on a calendar event.
+This property indicates that the server SHOULD retain resources that disappear
+from the feed. Services MAY define some mechanism to indicate that a particular
+resource SHOULD be removed. For example this specification suggests setting a
+status of DELETED on a calendar event.
+
 Definition::
 +
 [source%unnumbered]
@@ -65,16 +82,21 @@ Definition::
 === DAV:subscription-disabled
 
 Name:: subscription-disabled
+
 Namespace:: DAV
+
 Purpose:: To indicate that subscription has been disabled.
+
 Conformance:: This property MUST be reported for any disabled subscription.
-Description:: A server MAY choose to disable a subscription if there is an excessive number of
-errors when attempting to synchronize with the target This property indicates to the client
-that the subscription has been disabled.
+
+Description:: A server MAY choose to disable a subscription if there is an
+excessive number of errors when attempting to synchronize with the target This
+property indicates to the client that the subscription has been disabled.
 +
-There is no explicit action that can be taken to reenable a subscription. However, on
-subsequent requests a client may indicate a refresh is desired which MAY have the effect of
-reenabling the subscription.
+There is no explicit action that can be taken to reenable a subscription.
+However, on subsequent requests a client may indicate a refresh is desired which
+MAY have the effect of reenabling the subscription.
+
 Definition::
 +
 [source%unnumbered]
@@ -85,11 +107,16 @@ Definition::
 === DAV:subscription-next-refresh-interval
 
 Name:: subscription-next-refresh-interval
+
 Namespace:: DAV
+
 Purpose:: To indicate the time interval till the next refresh of a subscription.
+
 Conformance:: This property MUST be reported for any active subscription.
-Description:: This provides a time period to the next refresh. It uses the period format
-defined in <<RFC3339>>.
+
+Description:: This provides a time period to the next refresh. It uses the
+period format defined in <<RFC3339>>.
+
 Definition::
 +
 [source%unnumbered]
@@ -97,6 +124,7 @@ Definition::
 <!ELEMENT subscription-next-refresh-interval (#PCDATA)>
 PCDATA value: a duration value
 ----
+
 Example::
 +
 [source%unnumbered]
@@ -108,11 +136,17 @@ Example::
 === DAV:subscription-suggested-refresh-interval
 
 Name:: subscription-suggested-refresh-interval
+
 Namespace:: DAV
-Purpose:: To indicate the desired time interval between refreshes of a subscription.
+
+Purpose:: To indicate the desired time interval between refreshes of a
+subscription.
+
 Conformance:: This property MUST be reported for any active subscription.
-Description:: This provides a suggested time period between refresh. It uses the period format
-defined in RFC 3339.
+
+Description:: This provides a suggested time period between refresh. It uses the
+period format defined in RFC 3339.
+
 Definition::
 +
 [source%unnumbered]
@@ -120,6 +154,7 @@ Definition::
 <!ELEMENT subscription-suggested-refresh-interval (#PCDATA)>
 PCDATA value: a duration value
 ----
+
 Example::
 +
 [source%unnumbered]

--- a/sources/sections/05-dav-properties.adoc
+++ b/sources/sections/05-dav-properties.adoc
@@ -1,0 +1,129 @@
+[[dav-properties]]
+== New DAV and CALDAV properties
+
+=== DAV:subscription
+
+Name:: subscription
+Namespace:: DAV
+Purpose:: To indicate that the resource is a subscription to an external resource which is
+managed by the server.
+Conformance:: When this is specified the request MUST also contain at least a
+DAV:subscription-href element as defined in this specification.
+Description:: The DAV:specification resource type element is used to indicate a collection
+that is a subscription. A subscription MUST report the DAV:subscription XML element in the
+value of the DAV: resourcetype property.
+Definition::
++
+[source%unnumbered]
+----
+<!ELEMENT subscription empty>
+----
+
+=== DAV:subscription-href
+
+Name:: subscription-href
+Namespace:: DAV
+Purpose:: Provides the url for the external subscription.
+Conformance:: This property MUST be defined on any collection which has a resource-type
+containing a DAV:subscription element.
+Definition::
++
+[source%unnumbered]
+----
+<!ELEMENT vpoll-max-items (#PCDATA)>
+PCDATA value: a url
+----
+Example::
++
+[source%unnumbered]
+----
+<D:subscription-href xmlns:D="DAV"
+>https://example.com/events.ics</D:subscription-href>
+----
+
+=== DAV:subscription-deletions-suppressed
+
+Name:: subscription-deletions-suppressed
+Namespace:: DAV
+Purpose:: To indicate that resources that no longer appear in the feed should be retained by
+the server.
+Conformance:: This property MAY be defined on any subscription.
+Description:: Many feeds provide only the current active set of resources. For example, a
+calendar feed may only contain events from the current date onwards - while many subscribers
+would like to retain a copy of all events received over time.
++
+This property indicates that the server SHOULD retain resources that disappear from the feed.
+Services MAY define some mechanism to indicate that a particular resource SHOULD be removed.
+For example this specification suggests setting a status of DELETED on a calendar event.
+Definition::
++
+[source%unnumbered]
+----
+<!ELEMENT subscription-deletions-suppressed empty>
+----
+
+=== DAV:subscription-disabled
+
+Name:: subscription-disabled
+Namespace:: DAV
+Purpose:: To indicate that subscription has been disabled.
+Conformance:: This property MUST be reported for any disabled subscription.
+Description:: A server MAY choose to disable a subscription if there is an excessive number of
+errors when attempting to synchronize with the target This property indicates to the client
+that the subscription has been disabled.
++
+There is no explicit action that can be taken to reenable a subscription. However, on
+subsequent requests a client may indicate a refresh is desired which MAY have the effect of
+reenabling the subscription.
+Definition::
++
+[source%unnumbered]
+----
+<!ELEMENT subscription-enabled empty>
+----
+
+=== DAV:subscription-next-refresh-interval
+
+Name:: subscription-next-refresh-interval
+Namespace:: DAV
+Purpose:: To indicate the time interval till the next refresh of a subscription.
+Conformance:: This property MUST be reported for any active subscription.
+Description:: This provides a time period to the next refresh. It uses the period format
+defined in <<RFC3339>>.
+Definition::
++
+[source%unnumbered]
+----
+<!ELEMENT subscription-next-refresh-interval (#PCDATA)>
+PCDATA value: a duration value
+----
+Example::
++
+[source%unnumbered]
+----
+<D:subscription-next-refresh-interval xmlns:D="DAV"
+>PT30M</D:subscription-next-refresh-interval>
+----
+
+=== DAV:subscription-suggested-refresh-interval
+
+Name:: subscription-suggested-refresh-interval
+Namespace:: DAV
+Purpose:: To indicate the desired time interval between refreshes of a subscription.
+Conformance:: This property MUST be reported for any active subscription.
+Description:: This provides a suggested time period between refresh. It uses the period format
+defined in RFC 3339.
+Definition::
++
+[source%unnumbered]
+----
+<!ELEMENT subscription-suggested-refresh-interval (#PCDATA)>
+PCDATA value: a duration value
+----
+Example::
++
+[source%unnumbered]
+----
+<D:subscription-suggested-refresh-interval xmlns:D="DAV"
+>PT30M</D:subscription-suggested-refresh-interval>
+----

--- a/sources/sections/06-refreshing.adoc
+++ b/sources/sections/06-refreshing.adoc
@@ -1,15 +1,16 @@
 [[refreshing]]
 == Refreshing and Reenabling the subscription
 
-When creating the subscription the client may indicate to the server a desired refresh interval
-using the subscription-suggested-refresh-interval property.
+When creating the subscription the client may indicate to the server a desired
+refresh interval using the subscription-suggested-refresh-interval property.
 
-The client may indicate to the server that a refresh of the data is desired by using the
-PROPPATCH method to set the subscription-next-refresh-interval to 0, e.g. "PT0S".
+The client may indicate to the server that a refresh of the data is desired by
+using the PROPPATCH method to set the subscription-next-refresh-interval to 0,
+e.g. "PT0S".
 
-A server MAY choose to always ignore the attempted refresh or to ignore the patch if it appears
-too often.
+A server MAY choose to always ignore the attempted refresh or to ignore the
+patch if it appears too often.
 
-If the server decides to initiate a refresh it MAY choose to respond with a 102 HTTP status
-indicating that it is still waiting for the data or a 202 HTTP status to indicate the request
-was accepted.
+If the server decides to initiate a refresh it MAY choose to respond with a 102
+HTTP status indicating that it is still waiting for the data or a 202 HTTP
+status to indicate the request was accepted.

--- a/sources/sections/06-refreshing.adoc
+++ b/sources/sections/06-refreshing.adoc
@@ -1,0 +1,15 @@
+[[refreshing]]
+== Refreshing and Reenabling the subscription
+
+When creating the subscription the client may indicate to the server a desired refresh interval
+using the subscription-suggested-refresh-interval property.
+
+The client may indicate to the server that a refresh of the data is desired by using the
+PROPPATCH method to set the subscription-next-refresh-interval to 0, e.g. "PT0S".
+
+A server MAY choose to always ignore the attempted refresh or to ignore the patch if it appears
+too often.
+
+If the server decides to initiate a refresh it MAY choose to respond with a 102 HTTP status
+indicating that it is still waiting for the data or a 202 HTTP status to indicate the request
+was accepted.

--- a/sources/sections/07-response-delays.adoc
+++ b/sources/sections/07-response-delays.adoc
@@ -1,0 +1,25 @@
+[[response-delays]]
+== Response Delays
+
+Implementations of this feature may have an outboard or background process handling the actual
+synchronization of the data. The target may be hosted on a slow service or the data may be very
+large.
+
+All these factors may lead to a significant delay in having data ready for delivery to the
+client.
+
+The following approaches are more or less appropriate for handling requests:
+
+Return with available data:: This is the normal behavior. The subscription looks like a regular
+collection so the server can respond to the normal requests with whatever data is available.
+
+Wait for completion:: If the synchronization process is active the server may just choose to
+wait. This risks a request timeout if the data synchronization takes a significant amount of
+time.
+
+Return 102 status(es):: The server may choose to wait but periodically send a 102 response to
+keep the connection alive.
+
+Return 202 status:: This is probably the best response. There is no need to indicate where the
+client should go to retrieve the data. All it needs to do is retry the operation after an
+appropriate delay.

--- a/sources/sections/07-response-delays.adoc
+++ b/sources/sections/07-response-delays.adoc
@@ -1,25 +1,26 @@
 [[response-delays]]
 == Response Delays
 
-Implementations of this feature may have an outboard or background process handling the actual
-synchronization of the data. The target may be hosted on a slow service or the data may be very
-large.
+Implementations of this feature may have an outboard or background process
+handling the actual synchronization of the data. The target may be hosted on a
+slow service or the data may be very large.
 
-All these factors may lead to a significant delay in having data ready for delivery to the
-client.
+All these factors may lead to a significant delay in having data ready for
+delivery to the client.
 
 The following approaches are more or less appropriate for handling requests:
 
-Return with available data:: This is the normal behavior. The subscription looks like a regular
-collection so the server can respond to the normal requests with whatever data is available.
+Return with available data:: This is the normal behavior. The subscription looks
+like a regular collection so the server can respond to the normal requests with
+whatever data is available.
 
-Wait for completion:: If the synchronization process is active the server may just choose to
-wait. This risks a request timeout if the data synchronization takes a significant amount of
-time.
+Wait for completion:: If the synchronization process is active the server may
+just choose to wait. This risks a request timeout if the data synchronization
+takes a significant amount of time.
 
-Return 102 status(es):: The server may choose to wait but periodically send a 102 response to
-keep the connection alive.
+Return 102 status(es):: The server may choose to wait but periodically send a
+102 response to keep the connection alive.
 
-Return 202 status:: This is probably the best response. There is no need to indicate where the
-client should go to retrieve the data. All it needs to do is retry the operation after an
-appropriate delay.
+Return 202 status:: This is probably the best response. There is no need to
+indicate where the client should go to retrieve the data. All it needs to do is
+retry the operation after an appropriate delay.

--- a/sources/sections/08-caldav-considerations.adoc
+++ b/sources/sections/08-caldav-considerations.adoc
@@ -1,0 +1,23 @@
+[[caldav-considerations]]
+== CalDAV service Considerations
+
+As mentioned above, this feature is particularly useful for CalDAV servers and clients. There
+are some specific considerations.
+
+=== Deleted events
+
+If subscription-deletions-suppressed is specified then the server SHOULD retain all events.
+However, the server MAY choose to remove old events once they become older than the
+CALDAV:min-date-time property as specified in <<RFC4791,section=5.2.6>>.
+
+=== CalDAV restrictions
+
+A server SHOULD apply all appropriate restrictions on events obtained from a subscription. In
+particular the CALDAV:min-date-time and CALDAV:max-date-time properties as specified in
+<<RFC4791,section=5.2.6>> and <<RFC4791,section=5.2.7>> SHOULD be applied.
+
+Additionally the CALDAV:max-resource-size property restricts the size of events and the CALDAV:max-instances property the number of instances.
+
+=== Invitations in Subscriptions
+
+Any reason not to allow them?

--- a/sources/sections/08-caldav-considerations.adoc
+++ b/sources/sections/08-caldav-considerations.adoc
@@ -1,22 +1,25 @@
 [[caldav-considerations]]
 == CalDAV service Considerations
 
-As mentioned above, this feature is particularly useful for CalDAV servers and clients. There
-are some specific considerations.
+As mentioned above, this feature is particularly useful for CalDAV servers and
+clients. There are some specific considerations.
 
 === Deleted events
 
-If subscription-deletions-suppressed is specified then the server SHOULD retain all events.
-However, the server MAY choose to remove old events once they become older than the
-CALDAV:min-date-time property as specified in <<RFC4791,section=5.2.6>>.
+If subscription-deletions-suppressed is specified then the server SHOULD retain
+all events. However, the server MAY choose to remove old events once they become
+older than the CALDAV:min-date-time property as specified in
+<<RFC4791,section=5.2.6>>.
 
 === CalDAV restrictions
 
-A server SHOULD apply all appropriate restrictions on events obtained from a subscription. In
-particular the CALDAV:min-date-time and CALDAV:max-date-time properties as specified in
-<<RFC4791,section=5.2.6>> and <<RFC4791,section=5.2.7>> SHOULD be applied.
+A server SHOULD apply all appropriate restrictions on events obtained from a
+subscription. In particular the CALDAV:min-date-time and CALDAV:max-date-time
+properties as specified in <<RFC4791,section=5.2.6>> and
+<<RFC4791,section=5.2.7>> SHOULD be applied.
 
-Additionally the CALDAV:max-resource-size property restricts the size of events and the CALDAV:max-instances property the number of instances.
+Additionally the CALDAV:max-resource-size property restricts the size of events
+and the CALDAV:max-instances property the number of instances.
 
 === Invitations in Subscriptions
 

--- a/sources/sections/09-security.adoc
+++ b/sources/sections/09-security.adoc
@@ -1,6 +1,6 @@
 [[security]]
 == Security Considerations
 
-Servers implementing this feature need to be aware of the risks entailed in using the URIs
-provided as values to subscription-href. See <<RFC3986>> for a discussion of the security
-considerations relating to URIs.
+Servers implementing this feature need to be aware of the risks entailed in
+using the URIs provided as values to subscription-href. See <<RFC3986>> for a
+discussion of the security considerations relating to URIs.

--- a/sources/sections/09-security.adoc
+++ b/sources/sections/09-security.adoc
@@ -1,0 +1,6 @@
+[[security]]
+== Security Considerations
+
+Servers implementing this feature need to be aware of the risks entailed in using the URIs
+provided as values to subscription-href. See <<RFC3986>> for a discussion of the security
+considerations relating to URIs.

--- a/sources/sections/10-privacy.adoc
+++ b/sources/sections/10-privacy.adoc
@@ -1,0 +1,7 @@
+[[privacy]]
+== Privacy Considerations
+
+Properties with a "URI" value type can expose their users to privacy leaks as any network access
+of the URI data can be tracked. Clients SHOULD NOT automatically download data referenced by the
+URI without explicit instruction from users. This specification does not introduce any
+additional privacy concerns beyond those described in <<RFC5545>>.

--- a/sources/sections/10-privacy.adoc
+++ b/sources/sections/10-privacy.adoc
@@ -1,7 +1,8 @@
 [[privacy]]
 == Privacy Considerations
 
-Properties with a "URI" value type can expose their users to privacy leaks as any network access
-of the URI data can be tracked. Clients SHOULD NOT automatically download data referenced by the
-URI without explicit instruction from users. This specification does not introduce any
-additional privacy concerns beyond those described in <<RFC5545>>.
+Properties with a "URI" value type can expose their users to privacy leaks as
+any network access of the URI data can be tracked. Clients SHOULD NOT
+automatically download data referenced by the URI without explicit instruction
+from users. This specification does not introduce any additional privacy
+concerns beyond those described in <<RFC5545>>.

--- a/sources/sections/11-iana.adoc
+++ b/sources/sections/11-iana.adoc
@@ -1,0 +1,2 @@
+[[iana]]
+== IANA Considerations

--- a/sources/sections/99-acknowledgements.adoc
+++ b/sources/sections/99-acknowledgements.adoc
@@ -1,0 +1,11 @@
+[acknowledgments]
+== Acknowledgements
+
+The author would also like to thank the members of the Calendaring and Scheduling Consortium
+Calendar Sharing technical committee and the following individuals for contributing their ideas
+and support.
+
+...
+
+The authors would also like to thank CalConnect, the Calendaring and Scheduling Consortium, for
+advice with this specification.

--- a/sources/sections/99-acknowledgements.adoc
+++ b/sources/sections/99-acknowledgements.adoc
@@ -1,11 +1,11 @@
 [acknowledgments]
 == Acknowledgements
 
-The author would also like to thank the members of the Calendaring and Scheduling Consortium
-Calendar Sharing technical committee and the following individuals for contributing their ideas
-and support.
+The author would also like to thank the members of the Calendaring and
+Scheduling Consortium Calendar Sharing technical committee and the following
+individuals for contributing their ideas and support.
 
 ...
 
-The authors would also like to thank CalConnect, the Calendaring and Scheduling Consortium, for
-advice with this specification.
+The authors would also like to thank CalConnect, the Calendaring and Scheduling
+Consortium, for advice with this specification.


### PR DESCRIPTION
Closes #2 .

Notes: 
* The structure of this document differs in that "Conventions" is a subsection of the Introduction. In most documents, "Conventions" is a separate section following the Introduction, and for those documents, I have renamed "Conventions" to "Terms and Definitions" to align with CC's format. In this case, the original structure remains unchanged. Please let me know if any adjustments are needed.
* Open Issues subsection under Abstract is encoded in the IETF version only. Please let me know if it needs to be added to the CC version as well.